### PR TITLE
feat: Disables memory limit in phpunit job

### DIFF
--- a/php7.0-phpunit5/Dockerfile
+++ b/php7.0-phpunit5/Dockerfile
@@ -17,5 +17,7 @@ RUN pecl install xdebug \
         /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && php -m | grep xdebug
 
+RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini"
+
 ENV PATH /root/.composer/vendor/bin:$PATH
 CMD ["phpunit"]

--- a/php7.0-phpunit6/Dockerfile
+++ b/php7.0-phpunit6/Dockerfile
@@ -17,5 +17,7 @@ RUN pecl install xdebug \
         /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && php -m | grep xdebug
 
+RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini"
+
 ENV PATH /root/.composer/vendor/bin:$PATH
 CMD ["phpunit"]

--- a/php7.1-phpunit5/Dockerfile
+++ b/php7.1-phpunit5/Dockerfile
@@ -17,5 +17,7 @@ RUN pecl install xdebug \
         /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && php -m | grep xdebug
 
+RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini"
+
 ENV PATH /root/.composer/vendor/bin:$PATH
 CMD ["phpunit"]

--- a/php7.1-phpunit6/Dockerfile
+++ b/php7.1-phpunit6/Dockerfile
@@ -17,5 +17,7 @@ RUN pecl install xdebug \
         /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && php -m | grep xdebug
 
+RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini"
+
 ENV PATH /root/.composer/vendor/bin:$PATH
 CMD ["phpunit"]

--- a/php7.1-phpunit7/Dockerfile
+++ b/php7.1-phpunit7/Dockerfile
@@ -17,5 +17,7 @@ RUN pecl install xdebug \
         /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && php -m | grep xdebug
 
+RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini"
+
 ENV PATH /root/.composer/vendor/bin:$PATH
 CMD ["phpunit"]

--- a/php7.2-phpunit5/Dockerfile
+++ b/php7.2-phpunit5/Dockerfile
@@ -17,5 +17,7 @@ RUN pecl install xdebug \
         /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && php -m | grep xdebug
 
+RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini"
+
 ENV PATH /root/.composer/vendor/bin:$PATH
 CMD ["phpunit"]

--- a/php7.2-phpunit6/Dockerfile
+++ b/php7.2-phpunit6/Dockerfile
@@ -17,5 +17,7 @@ RUN pecl install xdebug \
         /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && php -m | grep xdebug
 
+RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini"
+
 ENV PATH /root/.composer/vendor/bin:$PATH
 CMD ["phpunit"]

--- a/php7.2-phpunit7/Dockerfile
+++ b/php7.2-phpunit7/Dockerfile
@@ -17,5 +17,7 @@ RUN pecl install xdebug \
         /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && php -m | grep xdebug
 
+RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini"
+
 ENV PATH /root/.composer/vendor/bin:$PATH
 CMD ["phpunit"]


### PR DESCRIPTION
# What I did
When running phpunit, we may want may memory than the default one sometimes.
Here is a patch to disable memory limit in php.

# How I did
Set memory_limit to `-1`

# How I tested
Entered the container with bash and ran this php application (taken from [here](https://stackoverflow.com/questions/10208698/checking-memory-limit-in-php))

**Note**: I only tested it on **php7.2-phpunit7**

```
<?php
$memory_limit = ini_get('memory_limit');
if (preg_match('/^(\d+)(.)$/', $memory_limit, $matches)) {
    if ($matches[2] == 'M') {
        $memory_limit = $matches[1] * 1024 * 1024; // nnnM -> nnn MB
    } else if ($matches[2] == 'K') {
        $memory_limit = $matches[1] * 1024; // nnnK -> nnn KB
    }
}

$ok = ($memory_limit >= 640 * 1024 * 1024); // at least 64M?

echo '<phpmem>';
echo '<val>' . $memory_limit . '</val>';
echo '<ok>' . ($ok ? 1 : 0) . '</ok>';
echo '</phpmem>';
```

**Output**
`<phpmem><val>-1</val><ok>0</ok></phpmem>`

